### PR TITLE
deploy to rubygems.org upon tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+dist: focal
+language: generic
+
+deploy:
+  edge: true # opt in to dpl v2
+  provider: rubygems
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -5,14 +5,10 @@ This gem provides base RuboCop configuration files for Ruby projects at Medidata
 
 ## Installation
 
-Add the following lines to your application's Gemfile:
+Add the following line to your application's Gemfile:
 
 ```ruby
-git_source(:github) { |repo| "git@github.com:#{repo}.git" }
-
-group :development, :test do
-  gem "rubocop-mdsol", github: "mdsol/rubocop-mdsol", tag: "<latest tag>"
-end
+gem "rubocop-mdsol", "~> 0.1"
 ```
 
 


### PR DESCRIPTION
~Let's hope I didn't botch the API key... 😅 ~

I'll set the API key directly in the env vars in the travis settings. Easier to manage there.

Thus, nothing much to see here!