### PR TITLE
Fix README instructions for vanilla ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ inherit_gem:
 Plain ruby projects only need to inherit from the base configuration file:
 
 ```yaml
-inherit_from:
+inherit_gem:
   rubocop-mdsol: rubocop.yml
 
 # your customizations here...


### PR DESCRIPTION
Adjust the README for vanilla ruby to also use [the required `inherit_gem` syntax](https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem)