### PR TITLE
bump max line length

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -19,8 +19,9 @@ Lint/AmbiguousBlockAssociation:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
+#####.....#####.....#####.....#####.....#####.....#####.....#####.....#####.....#####.....#####.....#####.....#####.....#####.....#####..... 145
 Layout/LineLength:
-  Max: 120
+  Max: 145
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented


### PR DESCRIPTION
Our code base have so many extremely long lines, 200 chars isn't rare, there are lines that are much longer.
Hitting the 120 target is just never going to happen.

Plus, over the years, GitHub has made it easier to review lines. I remember when 115 was the magic number.
And it got bump a few times.

I find that 145 is a very decent default for our organization