### PR TITLE
update rubocop version in example setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This gem provides base RuboCop configuration files for Ruby projects at Medidata
 Add the following line to your application's Gemfile:
 
 ```ruby
-gem "rubocop-mdsol", "~> 0.1"
+gem "rubocop-mdsol", "~> 0.3"
 ```
 
 


### PR DESCRIPTION
Current version is `0.3.0` whereas in README is uses `~> 0.1` as an example 👀 